### PR TITLE
Updated push user/password to descriptive name

### DIFF
--- a/.ci/actor.yml
+++ b/.ci/actor.yml
@@ -38,9 +38,9 @@ variables:
   - name: WASH_SUBJECT_KEY
     value: $[variables.SERVICE_APPLIER_KEY]
   - name: PUSH_USER
-    value: $[variables.COSMONIC_AZURECR_PUSH_USER]
+    value: $[variables.WASMCLOUD_AZURECR_PUSH_USER]
   - name: PUSH_PASSWORD
-    value: $[variables.COSMONIC_AZURECR_PUSH_PASSWORD]
+    value: $[variables.WASMCLOUD_AZURECR_PUSH_PASSWORD]
 
 stages:
   - stage: build_and_check

--- a/.ci/provider.yml
+++ b/.ci/provider.yml
@@ -38,9 +38,9 @@ variables:
   - name: WASH_SUBJECT_KEY
     value: $[variables.COSMONIC_KUBERNETES_APPLIER_KEY]
   - name: PUSH_USER
-    value: $[variables.COSMONIC_AZURECR_PUSH_USER]
+    value: $[variables.WASMCLOUD_AZURECR_PUSH_USER]
   - name: PUSH_PASSWORD
-    value: $[variables.COSMONIC_AZURECR_PUSH_PASSWORD]
+    value: $[variables.WASMCLOUD_AZURECR_PUSH_PASSWORD]
 
 stages:
   - stage: build_and_check


### PR DESCRIPTION
## Primary Reviewer
@thomastaylor312 

## Feature or Problem
Previously, this repo referred to names of secrets that weren't quite descriptive, so I renamed them to better indicate that they authenticate to wasmcloud's Azure registry.
